### PR TITLE
fix -D option

### DIFF
--- a/lib/yard/cli/spellcheck.rb
+++ b/lib/yard/cli/spellcheck.rb
@@ -70,7 +70,7 @@ module YARD
         opts.separator description
         opts.separator ""
 
-        opts.on('-D','--dict-dir','Dictionary directory') do |dir|
+        opts.on('-D','--dict-dir DIR','Dictionary directory') do |dir|
           FFI::Hunspell.directories << File.expand_path(dir)
         end
 


### PR DESCRIPTION
Just a minor fix. Got this error on ruby 1.9.2 prior to the fix:

```
$ yard-spellcheck -D ~/Downloads/en_US
/Users/bozo/.rvm/gems/ruby-1.9.2-p180@blah/gems/yard-spellcheck-0.1.2/lib/yard/cli/spellcheck.rb:74:in `expand_path': can't convert true into String (TypeError)
    from /Users/bozo/.rvm/gems/ruby-1.9.2-p180@blah/gems/yard-spellcheck-0.1.2/lib/yard/cli/spellcheck.rb:74:in `block in optparse'
    from /Users/bozo/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/optparse.rb:1308:in `call'
```
