### PR TITLE
fix ignore options

### DIFF
--- a/lib/yard/cli/spellcheck.rb
+++ b/lib/yard/cli/spellcheck.rb
@@ -83,7 +83,7 @@ module YARD
         end
 
         opts.on('-I','--ignore WORD','Words to ignore') do |word|
-          @checker.ignored << word
+          @checker.ignore << word
         end
 
         opts.on('-a','--add WORD [...]','Adds a word') do |word|

--- a/lib/yard/spellcheck/checker.rb
+++ b/lib/yard/spellcheck/checker.rb
@@ -53,7 +53,7 @@ module YARD
         @added = Set[]
 
         if options[:ignore]
-          @ignored += options[:add]
+          @ignore += options[:ignore]
         end
 
         if options[:add]


### PR DESCRIPTION
Noticed these while trying to use the -I option.

On an unrelated note, are you using a computer/web focused dictionary? On larger projects, I'm finding many common words being marked as misspelled i.e.: http html ssl www cmd yaml yml plugin json org eval regex. If you have the same issue, would you be open to an add_file option which adds the words in a given file? I realize this is a simpler version of loading a dictionary (hunspell -d) but at least it's a quick fix that won't require adding new ffi methods in ffi-hunspell
